### PR TITLE
Docs - fix import name of TQDMProgressBar

### DIFF
--- a/docs/source-pytorch/extensions/logging.rst
+++ b/docs/source-pytorch/extensions/logging.rst
@@ -324,10 +324,10 @@ if you are using a logger. These defaults can be customized by overriding the
 
 .. code-block:: python
 
-    from pytorch_lightning.callbacks.progress import Tqdm
+    from pytorch_lightning.callbacks.progress import TQDMProgressBar
 
 
-    class CustomProgressBar(Tqdm):
+    class CustomProgressBar(TQDMProgressBar):
         def get_metrics(self, *args, **kwargs):
             # don't show the version number
             items = super().get_metrics()


### PR DESCRIPTION
## What does this PR do?

Minor fix in documentation - the naming of the TQDM progress bar class has probably changed at some points and the docs were not updated accordingly. 

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [X] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [X] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [X] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [X] Did you list all the **breaking changes** introduced by this pull request?
- [] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
